### PR TITLE
Unescape single quotes for nonce calculation

### DIFF
--- a/rest_framework_signature/authentication.py
+++ b/rest_framework_signature/authentication.py
@@ -133,9 +133,11 @@ class TokenAuthentication(rest_framework.authentication.BaseAuthentication):
 
         # grab url request is for
         url = uri_to_iri(request.get_full_path())
-        # Un-escape the pipe character, for the url nonce calculation specifically
+
+        # Un-escape the following characters, for the url nonce calculation specifically
         url = url.replace('%7C', '|')
         url = url.replace('%20', ' ')
+        url = url.replace('%27', '\'')
 
         # if no api key was passed in raise error
         if not api_key:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-signature',
-    version='1.4.2.dev1',
+    version='1.4.3.dev1',
     description='Django Rest Framework Signature Authentication',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',


### PR DESCRIPTION
[encodeURI](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI#description) used to calculate the nonce by ng-core does not escape single quotes, but single quotes are received by signature as percent-encodings ("%" followed by two hexadecimal digits).

Original request `example.com/resource?field=Field Name With 'Quotes'` 
Frontend nonce calculation with encodeURI `example.com/resource?field=Field%20Name%20With%20'Quotes'`
Backend receives this to perform nonce calculation `example.com/resource?field=Field%20Name%20With%20%27Quotes%27`