### PR TITLE
Lh switchto cmg images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,8 +6,8 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/python:3.6.5
-      - image: circleci/postgres:9.6.2
+      - image: cimg/python:3.6.9
+      - image: cimg/postgres:9.6.24
         environment:
           POSTGRES_USER=test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - checkout
 
+      - run:
+          name: update apt-get
+          command: |
+            sudo apt-get update
       # need to install pyodbc dependency
       - run:
           name: pyodbc dependency

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-signature',
-    version='1.4.4.dev1',
+    version='1.4.5.dev1',
     description='Django Rest Framework Signature Authentication',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',


### PR DESCRIPTION
Upgrading to the newer Circleci images, as they are built on Ubuntu 20.

The previous images uses a non-support version of Ubuntu that can no longer install packages through apt-get.