### PR TITLE
Provide a way to override user in test cases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-signature',
-    version='4.0.0.dev1',
+    version='4.0.1.dev1',
     description='Django Rest Framework Signature Authentication',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',


### PR DESCRIPTION
This provides a way to specify a user when setting up the `api_client`.

It is a somewhat flawed idea in that the `_sha1_password` will be incorrect given a user is provided outside of the `create_user` method. Additionally, overriding the user on a case by case basis may introduce flakey results based on the order tests run. However, I do believe it is a reasonable pattern to setup the client with a specific user in the `setUp` method.

This PR also refactors the test classes to share functionality. I believe the minor differences in the `Trasactional` test class are not intentional.