### PR TITLE
Audit error responses

### DIFF
--- a/rest_framework_signature/exceptions.py
+++ b/rest_framework_signature/exceptions.py
@@ -1,4 +1,12 @@
+from rest_framework.exceptions import APIException
+from rest_framework import status
+
+
 class InvalidAuthSettings(Exception):
     def __init__(self, message):
         # Call the base class constructor with the parameters it needs
         super(InvalidAuthSettings, self).__init__(message)
+
+
+class SignatureException(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST

--- a/rest_framework_signature/views.py
+++ b/rest_framework_signature/views.py
@@ -11,6 +11,7 @@ from rest_framework_signature.serializers import AuthTokenSerializer, SSOTokenSe
 from rest_framework_signature.settings import auth_settings
 from rest_framework import status, authentication
 from rest_framework.authtoken.views import ObtainAuthToken
+from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -22,10 +23,7 @@ class DeleteAuthToken(APIView):
         auth_token_model = auth_settings.get_auth_token_document()
         auth = authentication.get_authorization_header(request).split()
 
-        try:
-            token = auth_token_model.objects.get(user=request.user, key=auth[1].decode('utf-8'))
-        except ObjectDoesNotExist:
-            return Response(status=status.HTTP_400_BAD_REQUEST)
+        token = auth_token_model.objects.get(user=request.user, key=auth[1].decode('utf-8'))
         token.delete()
 
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -65,12 +63,10 @@ class GetAuthToken(ObtainAuthToken):
                 user.last_failed_login = timezone.now()
                 user.save()
                 if user.failed_login_attempts >= auth_settings.FAILED_LOGIN_RETRY_ATTEMPTS:
-                    response = {'error_message': ErrorMessages.TOO_MANY_INCORRECT_LOGIN_ATTEMPTS}
-                    return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+                    raise APIException(ErrorMessages.TOO_MANY_INCORRECT_LOGIN_ATTEMPTS)
             except ObjectDoesNotExist:
                 pass
-        response = {'error_message': serializer.friendly_error_message}
-        return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+        raise APIException(serializer.friendly_error_message)
 
 
 class GetAuthTokenSSO(ObtainAuthToken):
@@ -97,8 +93,7 @@ class GetAuthTokenSSO(ObtainAuthToken):
             return Response(response, content_type='application/json', status=status.HTTP_200_OK)
 
         # todo: block them if too many sso attempts?
-        response = {'error_message': ErrorMessages.INVALID_CREDENTIALS}
-        return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+        raise APIException(ErrorMessages.INVALID_CREDENTIALS)
 
 
 class ResetPassword(APIView):
@@ -108,14 +103,12 @@ class ResetPassword(APIView):
 
         username = request.data.get('username', None)
         if not username:
-            response = {'error_message': ErrorMessages.MISSING_USERNAME}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.MISSING_USERNAME)
 
         try:
             user = self.user_model.objects.get(username=username)
         except ObjectDoesNotExist:
-            response = {'error_message': ErrorMessages.INVALID_USERNAME}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.INVALID_USERNAME)
 
         # create verification token
         user.password_reset_token = binascii.hexlify(os.urandom(22)).decode()
@@ -136,19 +129,16 @@ class CheckPasswordResetLink(APIView):
         reset_token = request.data.get('reset_token', None)
 
         if not reset_token:
-            response = {'error_message': ErrorMessages.INVALID_RESET_PASSWORD_TOKEN}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
         try:
             user = self.user_model.objects.get(password_reset_token=reset_token)
         except ObjectDoesNotExist:
-            response = {'error_message': ErrorMessages.INVALID_RESET_PASSWORD_TOKEN}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
         valid_reset_token = check_valid_reset_token(reset_token, user)
         if not valid_reset_token:
-            response = {'error_message': ErrorMessages.INVALID_RESET_PASSWORD_TOKEN}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
         response = {'success': True}
         return Response(response, status=status.HTTP_200_OK)
@@ -162,24 +152,20 @@ class SubmitNewPassword(APIView):
         reset_token = request.data.get('reset_token', None)
 
         if not reset_token:
-            response = {'error_message': ErrorMessages.INVALID_RESET_PASSWORD_TOKEN}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
         try:
             user = self.user_model.objects.get(password_reset_token=reset_token)
         except ObjectDoesNotExist:
-            response = {'error_message': ErrorMessages.INVALID_RESET_PASSWORD_TOKEN}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
         valid_reset_token = check_valid_reset_token(reset_token, user)
         if not valid_reset_token:
-            response = {'error_message': ErrorMessages.INVALID_RESET_PASSWORD_TOKEN}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
         password = request.data.get('password', None)
         if not password:
-            response = {'error_message': ErrorMessages.NO_PASSWORD}
-            return Response(response, content_type='application/json', status=status.HTTP_400_BAD_REQUEST)
+            raise APIException(ErrorMessages.NO_PASSWORD)
 
         m = hashlib.sha1()
         if user.salt is None:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-signature',
-    version='4.0.1.dev1',
+    version='4.0.2.dev1',
     description='Django Rest Framework Signature Authentication',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',

--- a/test_projects/test_proj/test_app/tests.py
+++ b/test_projects/test_proj/test_app/tests.py
@@ -226,7 +226,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         result = self.api_client.post(url, body, **headers)
 
         # assert
-        self.assertEquals(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEquals(result.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_sso_login_with_multiple_token_classes_fails(self):
         # arrange
@@ -238,7 +238,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         result = self.api_client.post(url, body, **headers)
 
         # assert
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch('rest_framework_signature.settings.auth_settings.get_sso_token_classes')
     def test_sso_login_fails_with_no_(self, mock_sso_classes):
@@ -253,7 +253,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         result = self.api_client.post(url, body, **headers)
 
         # assert
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
 
     @patch('test_projects.test_proj.test_app.views.UserHandler.get')
     def test_add_api_key_id_to_request(self, mock_get):
@@ -338,7 +338,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {'reset_token': self.user.password_reset_token}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
     def test_post_check_reset_password_link_invalid_reset_token(self):
@@ -346,7 +346,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {'reset_token': '12315sdf'}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
     def test_post_check_reset_password_link_no_reset_token(self):
@@ -354,7 +354,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
     def test_post_login(self):
@@ -408,7 +408,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         }
         for x in range(20):
             result = self.api_client.post(url, body, format='json')
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.TOO_MANY_INCORRECT_LOGIN_ATTEMPTS)
 
     def test_post_login_with_incorrect_password_updates_failed_login_attempts(self):
@@ -418,7 +418,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
             'password': 'wrong'
         }
         result = self.api_client.post(url, body, format='json')
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_CREDENTIALS)
         user = self.user_model.objects.get(username=self.user.username)
         self.assertEqual(user.failed_login_attempts, 1)
@@ -430,7 +430,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
             'password': 'wrong'
         }
         result = self.api_client.post(url, body, format='json')
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_CREDENTIALS)
         user = self.user_model.objects.get(username=self.user.username)
         self.assertIsNotNone(user.last_failed_login)
@@ -442,14 +442,14 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
             'password': self.sha1_password
         }
         result = self.api_client.post(url, body, format='json')
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_CREDENTIALS)
 
     def test_post_login_with_no_username(self):
         url = '/auth/login'
         body = {}
         result = self.api_client.post(url, body, format='json')
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.MISSING_USERNAME_OR_PASSWORD)
 
     def test_post_logout(self):
@@ -463,7 +463,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {'username': 'doesnotexist@test.com'}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_USERNAME)
 
     def test_post_reset_password_no_username(self):
@@ -471,7 +471,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.MISSING_USERNAME)
 
     def test_post_reset_password_sets_reset_password_token(self):
@@ -489,7 +489,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
     def test_post_submit_new_password_invalid_reset_token(self):
@@ -497,7 +497,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {'reset_token': '12315sdf'}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
     def test_post_submit_new_password_link_expired_token(self):
@@ -509,7 +509,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {'reset_token': self.user.password_reset_token}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.INVALID_RESET_PASSWORD_TOKEN)
 
     def test_post_submit_new_password_link_no_password(self):
@@ -521,7 +521,7 @@ class AuthenticationTests(RestFrameworkSignatureTestClass):
         body = {'reset_token': self.user.password_reset_token}
         headers = self.get_headers_without_auth(url, body)
         result = self.api_client.post(url, body, format='json', **headers)
-        self.assertEqual(result.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        self.assertEqual(result.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(result.data['detail'], ErrorMessages.NO_PASSWORD)
 
     def test_post_submit_new_password_link(self):


### PR DESCRIPTION
This PR replaces places where we return `Response` with raising `APIException`s. It is related to https://github.com/Skylude/django-rest-framework-simplify/pull/61 where many of the comments apply here.

Note the breaking change in this PR where `error_message` may become `errorMessage` (in our case using the simplify handler it will). This is likely not an issue in my opinion as it makes things more consistent and I've manually checked the usages.

This project caught me off guard for a moment because it has no concept of simplify and the simplify exception handler. Raising an `Exception` will not work because the default Django exception handler will bubble the exception up past the error response. Causing the related unit test to exit early.

I haven't tested if there is a code reason this project cannot depend on simplify. I do get the feeling it may be by design that this project or just the test projects don't depend on simplify. For this reason I've decided to stay away from the idea of using the simplify exception handler here. There are better alternatives in my opinion anyways.

For a project using the default Django error handler we will be returning the detailed error messages. However, that is a problem that does not exist for me, because we are using the simplify exception handler. It may even be the "right" idea for the default handler, because in my opinion the default handler doesn't make many guarantees about the sensitivity of the information error responses contain.

The solution presented will work for what we are trying to achieve. Looking at the exceptions being raised we will be using the `default_detail` from whatever derivative of `APIException` is being raised. So we have our guarantees about the level of detail in the error messages. We will see the real message in the logger under `exc_detail` and `exc_first_arg` so we retain the ability to debug this code.