### PR TITLE
Fix instance vs definition for AnonymousUser paths in authentication class

### DIFF
--- a/rest_framework_signature/authentication.py
+++ b/rest_framework_signature/authentication.py
@@ -1,7 +1,6 @@
 import re
 
 import rest_framework.authentication
-from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import uri_to_iri
 from rest_framework import exceptions
@@ -30,34 +29,33 @@ class TokenAuthentication(rest_framework.authentication.BaseAuthentication):
     unsecured_urls = auth_settings.UNSECURED_URLS
 
     def authenticate(self, request):
-
         # if it is an unsecured url then bypass auth
         request_path = request.path
         if (request.method, request_path) in self.unsecured_urls:
-            return
+            return None
 
         # first check if they are sending a super key to bypass all auth
         super_key_header = auth_settings.SUPER_KEY_HEADER
         super_key = request.META.get(super_key_header, None) if super_key_header else None
         if super_key and auth_settings.SUPER_KEY_AUTH and super_key == auth_settings.SUPER_KEY_AUTH:
-            return AnonymousUser, None
+            return None
 
         # first thing check the signature of the request
         api_key = self.check_signature(request)
 
         # special case for posting new users
         if (request.method, request_path) in self.bypass_auth_urls:
-            return
+            return None
 
         # if they've disabled user auth simply return an anonymous user
         if auth_settings.DISABLE_USER_AUTH:
-            return AnonymousUser, None
+            return None
 
         # if specific API keys do not need user auth then bypass it
         bypass_user_auth_setting = auth_settings.BYPASS_USER_AUTH_API_KEY_NAMES and api_key.name in auth_settings.BYPASS_USER_AUTH_API_KEY_NAMES
         bypass_user_auth_api_key = hasattr(api_key, 'bypass_user_auth') and getattr(api_key, 'bypass_user_auth', False)
         if bypass_user_auth_setting or bypass_user_auth_api_key:
-            return AnonymousUser, None
+            return None
 
         # regular authentication
         auth_header = rest_framework.authentication.get_authorization_header(request)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-signature',
-    version='4.0.2.dev1',
+    version='4.0.4.dev1',
     description='Django Rest Framework Signature Authentication',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',


### PR DESCRIPTION
This PR modifies the following cases:
- If the request is in `unsecured_urls`. This was modified, but the meaning hasn't changed since a bare `return` inherently evaluates to `None`.
- If the request has a super key. This now evaluates to a `AnonymousUser` instance.
- If the request is in `bypass_auth_urls`. Same situation as the `unsecured_urls` case.
- If the `DISABLE_USER_AUTH` setting is on. This is the same as the super key case.
- If the api key is a bypass user auth through settings or the model. This is the same as the super key case.

Looking at the source of rest frameworks baked in authentication classes we see they return `None` or a user tuple. This makes sense when inspecting the calling code. [Here](https://github.com/encode/django-rest-framework/blob/main/rest_framework/request.py#L378) we see each authentication class is invoked. If all classes return `None`, the function makes it to call `_not_authenticated` where an instance of an `AnonymousUser` is assigned instead of a definition.

Having the definition returned causes problems as all properties evaluate to truthy objects regardless of their actual return value. For example `is_authenticated` evaluates to an object which is truthy although the property is hardcoded to return `False`.