### PR TITLE
Set FailedLoginAttempts to 0 When Resetting Password

### DIFF
--- a/rest_framework_signature/views.py
+++ b/rest_framework_signature/views.py
@@ -185,6 +185,7 @@ class SubmitNewPassword(APIView):
         user.password = m.hexdigest()
         user.password_reset_ip = request.META.get('REMOTE_ADDR', None)
         user.password_reset_token = None
+        user.failed_login_attempts = 0
         user.save()
 
         response = {'success': True}

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from distutils.core import setup
 
 setup(
     name='django-rest-framework-signature',
-    version='4.0.5.dev1',
+    version='4.0.6.dev1',
     description='Django Rest Framework Signature Authentication',
     author='Skyler Cain',
     author_email='skylercain@gmail.com',


### PR DESCRIPTION
 * Closes: https://rentdynamics.atlassian.net/browse/RP-18716
 * Support gets lots of requests from people who reset their password but are still unable to login. This is because resetting your password does not reset your failed login attempts. T1 has to spend a lot of time going into admin and resetting login attempts for people who reset their password after being locked out.